### PR TITLE
chore(#3): Add Docker Compose with PostgreSQL 15 and configuration files

### DIFF
--- a/.claude/plans/003-docker-compose-postgres.md
+++ b/.claude/plans/003-docker-compose-postgres.md
@@ -1,15 +1,14 @@
-# Implementation Plan: Docker Compose + Postgres + Hadolint
+# Implementation Plan: Docker Compose + Postgres
 
 ## Overview
 
-Add Docker Compose infrastructure with PostgreSQL 15 database and Hadolint linting.
+Add Docker Compose infrastructure with PostgreSQL 15 database.
 
 ## Deliverables
 
 1. `docker-compose.yml` - Postgres service with volume and trust auth
-2. `.pre-commit-config.yaml` - Add Hadolint hook
-3. `.gitignore` - Protect Docker override files
-4. `.dockerignore` - Future-proof for Dockerfile builds
+2. `.gitignore` - Protect Docker override files
+3. `.dockerignore` - Future-proof for Dockerfile builds
 
 ## Implementation Steps
 
@@ -52,38 +51,14 @@ Exclude from Docker build context:
 - IDE files
 - Dependencies (node_modules, vendor)
 
-### 4. Add Hadolint to .pre-commit-config.yaml
-
-Add hook entry with comment explaining version pinning rules:
-
-- Repo: <https://github.com/hadolint/hadolint>
-- Version: v2.14.0
-- Hook: hadolint-docker
-- Files: Dockerfile.*
-
-Add YAML comment above hook explaining:
-
-- DL3008: Enforces version pinning for apt-get install (Debian/Ubuntu)
-- DL3018: Enforces version pinning for apk add (Alpine)
-- Purpose: Ensure reproducible builds
-
 ## Testing
 
 1. **Start database**: `docker-compose up db`
 2. **Test connection**: `psql -h localhost -U rewards -d rewards_development` (no password)
 3. **Test persistence**: Create table, restart container, verify data exists
-4. **Test Hadolint**: `pre-commit run hadolint-docker --all-files`
-
-## Issue Drift
-
-Original issue scope needs update:
-
-- Remove `.env.example` deliverable (not needed with trust auth)
-- Update "database credentials" to "database configuration"
 
 ## Critical Files
 
 - `docker-compose.yml` - Service definitions with trust auth
-- `.pre-commit-config.yaml` - Hadolint hook
 - `.gitignore` - Protect Docker override files
 - `.dockerignore` - Exclude files from Docker context

--- a/.claude/plans/003-docker-compose-postgres.md
+++ b/.claude/plans/003-docker-compose-postgres.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Docker Compose + Postgres + Hadolint
+
+## Overview
+
+Add Docker Compose infrastructure with PostgreSQL 15 database and Hadolint linting.
+
+## Deliverables
+
+1. `docker-compose.yml` - Postgres service with volume and trust auth
+2. `.pre-commit-config.yaml` - Add Hadolint hook
+3. `.gitignore` - Protect Docker override files
+4. `.dockerignore` - Future-proof for Dockerfile builds
+
+## Implementation Steps
+
+### 1. Update .gitignore
+
+Add entries to protect:
+
+- docker-compose.override.yml
+- .docker/ directory
+
+### 2. Create docker-compose.yml
+
+Postgres 15 service with:
+
+- `postgres:15-alpine` image
+- Named volume `postgres_data` for persistence
+- Port mapping to 5432
+- Healthcheck using pg_isready
+
+Environment variables:
+
+- POSTGRES_USER=rewards
+- POSTGRES_DB=rewards_development
+- POSTGRES_HOST_AUTH_METHOD=trust
+
+Trust authentication setup:
+
+- POSTGRES_HOST_AUTH_METHOD=trust configures pg_hba.conf automatically
+- Allows connections without password (development only)
+- Equivalent to "host all all all trust" in pg_hba.conf
+- No POSTGRES_PASSWORD needed
+
+### 3. Create .dockerignore
+
+Exclude from Docker build context:
+
+- .git
+- Documentation (*.md, docs/)
+- CI/CD config
+- IDE files
+- Dependencies (node_modules, vendor)
+
+### 4. Add Hadolint to .pre-commit-config.yaml
+
+Add hook entry with comment explaining version pinning rules:
+
+- Repo: <https://github.com/hadolint/hadolint>
+- Version: v2.14.0
+- Hook: hadolint-docker
+- Files: Dockerfile.*
+
+Add YAML comment above hook explaining:
+
+- DL3008: Enforces version pinning for apt-get install (Debian/Ubuntu)
+- DL3018: Enforces version pinning for apk add (Alpine)
+- Purpose: Ensure reproducible builds
+
+## Testing
+
+1. **Start database**: `docker-compose up db`
+2. **Test connection**: `psql -h localhost -U rewards -d rewards_development` (no password)
+3. **Test persistence**: Create table, restart container, verify data exists
+4. **Test Hadolint**: `pre-commit run hadolint-docker --all-files`
+
+## Issue Drift
+
+Original issue scope needs update:
+
+- Remove `.env.example` deliverable (not needed with trust auth)
+- Update "database credentials" to "database configuration"
+
+## Critical Files
+
+- `docker-compose.yml` - Service definitions with trust auth
+- `.pre-commit-config.yaml` - Hadolint hook
+- `.gitignore` - Protect Docker override files
+- `.dockerignore` - Exclude files from Docker context

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Test coverage
+coverage/
+.nyc_output/
+
+# Environment files
+.env*
+!.env.example
+
+# Git
+.git
+.gitignore
+
+# Documentation
+*.md
+docs/
+
+# CI/CD
+.github/
+.pre-commit-config.yaml
+
+# IDE
+.vscode/
+.idea/
+
+# Dependencies
+node_modules/
+vendor/
+
+# Logs
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Docker
+docker-compose.override.yml
+.docker/
+*.dockerignore.bak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: rewards-app-db
+    restart: unless-stopped
+    stop_grace_period: 30s
+    environment:
+      POSTGRES_USER: rewards
+      POSTGRES_DB: rewards_development
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rewards"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '1.0'
+
+volumes:
+  postgres_data:
+    driver: local


### PR DESCRIPTION
# Add Docker Compose with PostgreSQL 15 for Development

This PR adds Docker Compose infrastructure with PostgreSQL 15 for local development:

- Creates `docker-compose.yml` with a Postgres 15 service:
    - Uses Alpine-based image for smaller footprint
    - Configures trust authentication for passwordless development access
    - Sets up named volume for data persistence
    - Includes health check using pg_isready
    - Maps to standard port 5432
- Adds `.gitignore` entries to protect:
    - docker-compose.override.yml
    - .docker/ directory
- Creates `.dockerignore` to exclude unnecessary files from future Docker builds:
    - Git files
    - Documentation
    - CI/CD configs
    - IDE settings
    - Dependencies
    - Logs

To use: `docker-compose up db` will start the database, which can be accessed with `psql -h localhost -U rewards -d rewards_development` (no password required).