### PR TITLE
feat(#9): Add Docker containerization for React frontend with multi-stage builds and SPA routing

### DIFF
--- a/.claude/plans/009-react-dockerfile.md
+++ b/.claude/plans/009-react-dockerfile.md
@@ -1,0 +1,132 @@
+# Implementation Plan: React Dockerfile
+
+**Issue:** #9 - <https://github.com/fabiolnm/rewards-app/issues/9>
+
+## Overview
+
+Add Docker containerization for the React frontend using multi-stage
+builds (Bun + Nginx), SPA routing configuration, and docker-compose
+integration.
+
+## Context
+
+**React App:**
+
+- Build tool: Vite 7.2.4
+- Package manager: Bun (bun.lockb present)
+- Build command: `bun run build` → outputs to `dist/`
+- No environment variables required (static app)
+
+**Existing Docker Patterns (from api/Dockerfile):**
+
+- Directives: `syntax=docker/dockerfile:1` and `check=error=true`
+- Multi-stage: base → build → final
+- Non-root user: uid/gid 1000
+- Production-focused with minimal runtime dependencies
+
+**docker-compose.yml Structure:**
+
+- Services: db (postgres:15-alpine, port 5432), api (port 3001:3000)
+- Container naming: `rewards-app-{service}`
+- Restart policy: `unless-stopped`
+
+**Requirements from Issue #9:**
+
+- Multi-stage Dockerfile (build + nginx)
+- nginx.conf for SPA routing
+- Update docker-compose.yml with web service
+- Must pass: `hadolint web/Dockerfile`
+- Must work: `docker-compose up web` serves app at localhost:3000
+
+## Implementation Steps
+
+### 1. Create Nginx Configuration (web/nginx.conf)
+
+**SPA Routing:**
+
+- `try_files $uri $uri/ /index.html` - fallback for client-side routing
+- Serve from `/usr/share/nginx/html`
+- Listen on port 80
+
+**Caching Headers:**
+
+- `index.html`: `no-cache` (always revalidate)
+- Hashed assets: `max-age=31536000, immutable` (Vite generates hashes)
+- Other assets: `max-age=86400` (1 day)
+
+**Additional:**
+
+- Gzip compression for text assets
+- Security headers (X-Frame-Options, X-Content-Type-Options)
+- Health check endpoint `/health`
+
+### 2. Create Multi-stage Dockerfile (web/Dockerfile)
+
+**Build Stage:**
+
+- Base: `oven/bun:1-slim` (official Bun image)
+- Install: `bun install --frozen-lockfile`
+- Build: `bun run build`
+- Output: `dist/` directory
+
+**Production Stage:**
+
+- Base: `nginx:1.27-alpine` (minimal footprint)
+- Copy `dist/` → `/usr/share/nginx/html`
+- Copy `nginx.conf` → `/etc/nginx/conf.d/default.conf`
+- Non-root: nginx user (uid 101, default in alpine)
+- Expose: port 80
+
+**Hadolint Compliance:**
+
+- Pin all image versions
+- Use `--frozen-lockfile` for reproducible builds
+- Layer caching: dependencies before source
+- Include `syntax` and `check` directives
+
+### 3. Update docker-compose.yml
+
+Add web service after api service:
+
+```yaml
+  web:
+    build:
+      context: ./web
+    container_name: rewards-app-web
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+```
+
+## Commits Plan
+
+**IMPORTANT: Create commits immediately after completing each step below.
+Do NOT wait until all work is done.**
+
+1. **docs(#9): Plan React Dockerfile**
+   - Create `.claude/plans/009-react-dockerfile.md`
+   - Submit to create PR with issue context
+
+2. **feat(#9): Add Nginx configuration for SPA routing**
+   - Create `web/nginx.conf`
+   - Configure SPA fallback, caching, gzip, security headers
+
+3. **feat(#9): Add multi-stage Dockerfile for React app**
+   - Create `web/Dockerfile`
+   - Build stage: Bun + Vite
+   - Production stage: Nginx + static files
+   - Verify: `hadolint web/Dockerfile` passes
+
+4. **feat(#9): Add web service to docker-compose**
+   - Update `docker-compose.yml`
+   - Add web service with port mapping 3000:80
+   - Verify: `docker-compose up web` works
+
+## Verification
+
+Full acceptance criteria:
+
+- [ ] `hadolint web/Dockerfile` passes
+- [ ] `docker-compose up web` serves React app
+- [ ] App accessible at localhost:3000
+- [ ] SPA routing works (all routes → index.html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,14 @@ services:
       - ./api/lib:/rails/lib
       - ./api/db:/rails/db
 
+  web:
+    build:
+      context: ./web
+    container_name: rewards-app-web
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+
 volumes:
   postgres_data:
     driver: local

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
+# Build stage
+FROM oven/bun:1.3.5-slim AS build
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json bun.lockb ./
+
+# Install dependencies
+RUN bun install --frozen-lockfile
+
+# Copy source code
+COPY . .
+
+# Build application
+RUN bun run build
+
+# Production stage
+FROM nginx:1.27.5-alpine
+
+# Copy built assets from build stage
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD wget --no-verbose --tries=1 --spider http://localhost/health || exit 1
+
+# Run as non-root user
+USER nginx
+
+# Expose port
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,41 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "OK\n";
+        add_header Content-Type text/plain;
+    }
+
+    # Cache hashed assets (Vite generates files with hashes)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|webp|avif|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Never cache index.html
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    # SPA routing - fallback to index.html for client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
# Add Docker containerization for React frontend

\\This PR adds Docker containerization for the React frontend with:

- Multi-stage Dockerfile using Bun for building and Nginx for serving
- Nginx configuration with SPA routing support
- Integration with docker-compose

The implementation:

- Creates a multi-stage `web/Dockerfile` that builds the React app with Bun and serves it with Nginx
- Adds `web/nginx.conf` with SPA routing fallbacks and optimized caching headers
- Updates `docker-compose.yml` to include the web service on port 3000

The React app can now be run with `docker-compose up web` and accessed at localhost:3000.

Closes #9